### PR TITLE
update libavr32, fix config.mk and SPI constants

### DIFF
--- a/src/config.mk
+++ b/src/config.mk
@@ -62,25 +62,25 @@ TARGET = $(THIS).elf
 
 # List of C source files.
 CSRCS = \
-       ../src/main.c    \
-       ../libavr32/src/adc.c     \
-       ../libavr32/src/events.c     \
-       ../libavr32/src/init_trilogy.c \
-       ../libavr32/src/init_common.c \
-       ../libavr32/src/i2c.c \
-       ../libavr32/src/interrupts.c \
-       ../libavr32/src/monome.c \
-       ../libavr32/src/timers.c \
-       ../libavr32/src/notes.c \
-       ../libavr32/src/usb.c \
-       ../libavr32/src/util.c \
-       ../libavr32/src/usb/ftdi/ftdi.c \
-       ../libavr32/src/usb/ftdi/uhi_ftdi.c \
-       ../libavr32/src/usb/hid/hid.c \
-       ../libavr32/src/usb/hid/uhi_hid.c \
-       ../libavr32/src/usb/midi/uhi_midi.c \
-       ../libavr32/src/usb/midi/midi.c \
-       ../libavr32/src/usb/msc/msc.c \
+       ../src/main.c                                      \
+       ../libavr32/src/adc.c                              \
+       ../libavr32/src/events.c                           \
+       ../libavr32/src/init_trilogy.c                     \
+       ../libavr32/src/init_common.c                      \
+			 ../libavr32/src/interrupts.c                       \
+       ../libavr32/src/i2c.c                              \
+       ../libavr32/src/monome.c                           \
+       ../libavr32/src/timers.c                           \
+       ../libavr32/src/notes.c                            \
+       ../libavr32/src/usb.c                              \
+       ../libavr32/src/util.c                             \
+       ../libavr32/src/usb/ftdi/ftdi.c                    \
+       ../libavr32/src/usb/ftdi/uhi_ftdi.c                \
+       ../libavr32/src/usb/hid/hid.c                      \
+       ../libavr32/src/usb/hid/uhi_hid.c                  \
+       ../libavr32/src/usb/midi/uhi_midi.c                \
+       ../libavr32/src/usb/midi/midi.c                    \
+			 ../libavr32/src/usb/msc/msc.c                      \
        avr32/drivers/adc/adc.c                            \
        avr32/drivers/flashc/flashc.c                      \
        avr32/drivers/gpio/gpio.c                          \
@@ -90,14 +90,14 @@ CSRCS = \
        avr32/drivers/pm/power_clocks_lib.c                \
        avr32/drivers/spi/spi.c                            \
        avr32/drivers/tc/tc.c                              \
-       avr32/drivers/twi/twi.c                              \
+       avr32/drivers/twi/twi.c                            \
        avr32/drivers/usart/usart.c                        \
        avr32/drivers/usbb/usbb_host.c                     \
        avr32/utils/debug/print_funcs.c                    \
        common/services/usb/class/msc/host/uhi_msc.c       \
        common/services/usb/class/msc/host/uhi_msc_mem.c   \
-       common/services/spi/uc3_spi/spi_master.c \
-       common/services/usb/uhc/uhc.c \
+       common/services/spi/uc3_spi/spi_master.c           \
+       common/services/usb/uhc/uhc.c                      \
        common/services/clock/uc3b0_b1/sysclk.c
 
 # List of assembler source files.
@@ -108,15 +108,15 @@ ASSRCS = \
 
 # List of include paths.
 INC_PATH = \
-       ../../src           \
-       ../src                                        \
-       ../src/usb \
-       ../src/usb/ftdi \
-       ../src/usb/hid \
-       ../src/usb/midi \
-       ../src/usb/msc \
-       ../conf      \
-       ../conf/trilogy \
+       ../../src                                          \
+       ../src                                             \
+       ../src/usb                                         \
+       ../src/usb/ftdi                                    \
+       ../src/usb/hid                                     \
+       ../src/usb/midi                                    \
+			 ../src/usb/msc                                     \
+       ../conf                                            \
+       ../conf/trilogy                                    \
        avr32/boards                                       \
        avr32/drivers/cpu/cycle_counter                    \
        avr32/drivers/flashc                               \
@@ -125,23 +125,23 @@ INC_PATH = \
        avr32/drivers/pm                                   \
        avr32/drivers/spi                                  \
        avr32/drivers/tc                                   \
-       avr32/drivers/twi                                   \
+       avr32/drivers/twi                                  \
        avr32/drivers/usart                                \
        avr32/drivers/usbb                                 \
        avr32/utils                                        \
        avr32/utils/debug                                  \
        avr32/utils/preprocessor                           \
        common/boards                                      \
-       common/boards/user_board \
+       common/boards/user_board                           \
        common/services/storage/ctrl_access                \
        common/services/clock                              \
        common/services/delay                              \
-       common/services/usb/ \
-       common/services/usb/uhc \
+       common/services/usb/                               \
+       common/services/usb/uhc                            \
        common/services/usb/class/msc                      \
        common/services/usb/class/msc/host                 \
        common/services/usb/class/hid                      \
-       common/services/spi/uc3_spi \
+       common/services/spi/uc3_spi                        \
        common/utils
 
 # Additional search paths for libraries.
@@ -183,7 +183,7 @@ CFLAGS =
 #   BOARD      Target board in use, see boards/board.h for a list.
 #   EXT_BOARD  Optional extension board in use, see boards/board.h for a list.
 CPPFLAGS = \
-      -D BOARD=USER_BOARD -D UHD_ENABLE -D EARTHSEA                            
+      -D BOARD=USER_BOARD -D UHD_ENABLE
 
 # Extra flags to use when linking
 LDFLAGS = \

--- a/src/main.c
+++ b/src/main.c
@@ -387,23 +387,23 @@ static softTimer_t midiPollTimer = { .next = NULL, .prev = NULL };
 static void aout_write(void) {
 	// cpu_irq_disable_level(APP_TC_IRQ_PRIORITY);
 
-	spi_selectChip(SPI,DAC_SPI_NPCS);
-	spi_write(SPI,0x31);
-	spi_write(SPI,aout[2].now>>4);
-	spi_write(SPI,aout[2].now<<4);
-	spi_write(SPI,0x31);
-	spi_write(SPI,aout[0].now>>4);
-	spi_write(SPI,aout[0].now<<4);
-	spi_unselectChip(SPI,DAC_SPI_NPCS);
+	spi_selectChip(DAC_SPI, DAC_SPI_NPCS);
+	spi_write(DAC_SPI, 0x31);
+	spi_write(DAC_SPI, aout[2].now>>4);
+	spi_write(DAC_SPI, aout[2].now<<4);
+	spi_write(DAC_SPI, 0x31);
+	spi_write(DAC_SPI, aout[0].now>>4);
+	spi_write(DAC_SPI, aout[0].now<<4);
+	spi_unselectChip(DAC_SPI, DAC_SPI_NPCS);
 
-	spi_selectChip(SPI,DAC_SPI_NPCS);
-	spi_write(SPI,0x38);
-	spi_write(SPI,aout[3].now>>4);
-	spi_write(SPI,aout[3].now<<4);
-	spi_write(SPI,0x38);
-	spi_write(SPI,aout[1].now>>4);
-	spi_write(SPI,aout[1].now<<4);
-	spi_unselectChip(SPI,DAC_SPI_NPCS);
+	spi_selectChip(DAC_SPI, DAC_SPI_NPCS);
+	spi_write(DAC_SPI, 0x38);
+	spi_write(DAC_SPI, aout[3].now>>4);
+	spi_write(DAC_SPI, aout[3].now<<4);
+	spi_write(DAC_SPI, 0x38);
+	spi_write(DAC_SPI, aout[1].now>>4);
+	spi_write(DAC_SPI, aout[1].now<<4);
+	spi_unselectChip(DAC_SPI, DAC_SPI_NPCS);
 
 	// cpu_irq_enable_level(APP_TC_IRQ_PRIORITY);
 }
@@ -1324,17 +1324,17 @@ static void shape(u8 s, u8 x, u8 y) {
 	if(!arp && r_status == rOff && !port_active) {
 		// cpu_irq_disable_level(APP_TC_IRQ_PRIORITY);
 
-		spi_selectChip(SPI,DAC_SPI_NPCS);
+		spi_selectChip(DAC_SPI, DAC_SPI_NPCS);
 
-		spi_write(SPI,0x38);	// update B
-		spi_write(SPI,aout[3].now>>4);
-		spi_write(SPI,aout[3].now<<4);
+		spi_write(DAC_SPI, 0x38);	// update B
+		spi_write(DAC_SPI, aout[3].now>>4);
+		spi_write(DAC_SPI, aout[3].now<<4);
 
-		spi_write(SPI,0x80);	// update B
-		spi_write(SPI,0xff);
-		spi_write(SPI,0xff);
+		spi_write(DAC_SPI, 0x80);	// update B
+		spi_write(DAC_SPI, 0xff);
+		spi_write(DAC_SPI, 0xff);
 
-		spi_unselectChip(SPI,DAC_SPI_NPCS);
+		spi_unselectChip(DAC_SPI, DAC_SPI_NPCS);
 
 		// cpu_irq_enable_level(APP_TC_IRQ_PRIORITY);
 	}
@@ -1426,17 +1426,17 @@ static void pattern_shape(u8 s, u8 x, u8 y) {
 		if(!port_active) {
 			// cpu_irq_disable_level(APP_TC_IRQ_PRIORITY);
 
-			spi_selectChip(SPI,DAC_SPI_NPCS);
+			spi_selectChip(DAC_SPI, DAC_SPI_NPCS);
 
-			spi_write(SPI,0x38);	// update B
-			spi_write(SPI,aout[3].now>>4);
-			spi_write(SPI,aout[3].now<<4);
+			spi_write(DAC_SPI, 0x38);	// update B
+			spi_write(DAC_SPI, aout[3].now>>4);
+			spi_write(DAC_SPI, aout[3].now<<4);
 
-			spi_write(SPI,0x80);	// update B
-			spi_write(SPI,0xff);
-			spi_write(SPI,0xff);
+			spi_write(DAC_SPI, 0x80);	// update B
+			spi_write(DAC_SPI, 0xff);
+			spi_write(DAC_SPI, 0xff);
 
-			spi_unselectChip(SPI,DAC_SPI_NPCS);
+			spi_unselectChip(DAC_SPI, DAC_SPI_NPCS);
 			// cpu_irq_enable_level(APP_TC_IRQ_PRIORITY);
 		}
 
@@ -2477,7 +2477,7 @@ int main(void)
 	init_usb_host();
 	init_monome();
 
-	init_i2c_slave(0x50);
+	init_i2c_follower(0x50);
 
 
 	print_dbg("\r\n\n// earthsea! //////////////////////////////// ");
@@ -2562,11 +2562,11 @@ int main(void)
 	// clock_external = !gpio_get_pin_value(B09);
 
 	// setup daisy chain for two dacs
-	spi_selectChip(SPI,DAC_SPI_NPCS);
-	spi_write(SPI,0x80);
-	spi_write(SPI,0xff);
-	spi_write(SPI,0xff);
-	spi_unselectChip(SPI,DAC_SPI_NPCS);
+	spi_selectChip(DAC_SPI, DAC_SPI_NPCS);
+	spi_write(DAC_SPI, 0x80);
+	spi_write(DAC_SPI, 0xff);
+	spi_write(DAC_SPI, 0xff);
+	spi_unselectChip(DAC_SPI, DAC_SPI_NPCS);
 
 	// ensure cvTimer_callback does something
 	slew_active = 1;


### PR DESCRIPTION
note: i changed the default branch in this repo to `main` ahead of this PR.

this change brings the earthsea firmware up to latest libavr32 (in anticipation of grid-st support). the changes were briefly tested on hardware.